### PR TITLE
fix: crash when clicking on install button.

### DIFF
--- a/app/src/main/kotlin/com/aliucord/manager/ui/viewmodel/InstallViewModel.kt
+++ b/app/src/main/kotlin/com/aliucord/manager/ui/viewmodel/InstallViewModel.kt
@@ -40,7 +40,7 @@ class InstallViewModel(
         private set
 
     init {
-        viewModelScope.launch {
+        viewModelScope.launch(Dispatchers.Main) {
             startInstallation()
         }
     }


### PR DESCRIPTION
Moving to separate thread fixes the error. here's the relevant issue and answer: https://stackoverflow.com/questions/66891349/java-lang-illegalstateexception-when-using-state-in-android-jetpack-compose/66935298#66935298 