### PR TITLE
fix: use ipv4 only for `raw.githubusercontent.com`

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -90,7 +90,7 @@ dependencies {
     // Ktor
     val ktorVersion = "2.1.1"
     implementation("io.ktor:ktor-client-core:$ktorVersion")
-    implementation("io.ktor:ktor-client-cio:$ktorVersion")
+    implementation("io.ktor:ktor-client-okhttp:$ktorVersion")
     implementation("io.ktor:ktor-client-content-negotiation:$ktorVersion")
     implementation("io.ktor:ktor-serialization-kotlinx-json:$ktorVersion")
 

--- a/app/src/main/kotlin/com/aliucord/manager/di/HttpModule.kt
+++ b/app/src/main/kotlin/com/aliucord/manager/di/HttpModule.kt
@@ -1,19 +1,33 @@
 package com.aliucord.manager.di
 
 import io.ktor.client.*
-import io.ktor.client.engine.cio.*
+import io.ktor.client.engine.okhttp.*
 import io.ktor.client.plugins.contentnegotiation.*
 import io.ktor.serialization.kotlinx.json.*
 import kotlinx.serialization.json.Json
+import okhttp3.Dns
 import org.koin.core.module.dsl.singleOf
 import org.koin.dsl.module
+import java.net.Inet4Address
+import java.net.InetAddress
 
 val httpModule =  module {
     fun provideJson() = Json {
         ignoreUnknownKeys = true
     }
 
-    fun provideHttpClient(json: Json) = HttpClient(CIO) {
+    fun provideHttpClient(json: Json) = HttpClient(OkHttp) {
+        engine {
+            config {
+                dns(object : Dns {
+                    override fun lookup(hostname: String): List<InetAddress> {
+                        // Github's nameservers do not respond to IPv6 requests for raw.githubusercontent.com,
+                        // which causes CIO, Android and OkHTTP to all hang
+                        return Dns.SYSTEM.lookup(hostname).filterIsInstance<Inet4Address>()
+                    }
+                })
+            }
+        }
         install(ContentNegotiation) {
             json(json)
         }

--- a/app/src/main/kotlin/com/aliucord/manager/di/HttpModule.kt
+++ b/app/src/main/kotlin/com/aliucord/manager/di/HttpModule.kt
@@ -21,9 +21,15 @@ val httpModule =  module {
             config {
                 dns(object : Dns {
                     override fun lookup(hostname: String): List<InetAddress> {
+                        val addresses = Dns.SYSTEM.lookup(hostname)
+
                         // Github's nameservers do not respond to IPv6 requests for raw.githubusercontent.com,
                         // which causes CIO, Android and OkHTTP to all hang
-                        return Dns.SYSTEM.lookup(hostname).filterIsInstance<Inet4Address>()
+                        return if (hostname == "raw.githubusercontent.com") {
+                            addresses.filterIsInstance<Inet4Address>()
+                        } else {
+                            addresses
+                        }
                     }
                 })
             }


### PR DESCRIPTION
Github's nameservers do not respond to ipv6 for raw.githubusercontent.com and caues all ktor engines to hang if not to explicitly ignore ipv6

On the contrary, now using OkHttp (it was already a dependency from something else) allows network inspector to work 