### PR TITLE
fix: apply correct monochrome icon

### DIFF
--- a/app/src/main/kotlin/com/aliucord/manager/patcher/steps/patch/PatchIconsStep.kt
+++ b/app/src/main/kotlin/com/aliucord/manager/patcher/steps/patch/PatchIconsStep.kt
@@ -178,9 +178,9 @@ class PatchIconsStep(private val options: PatchOptions) : Step(), KoinComponent 
         ZipWriter(apk, /* append = */ true).use {
             if (isMonochromeIconsAvailable) {
                 val monochromeIconId = if (options.iconReplacement is IconReplacement.OldDiscord) {
-                    R.drawable.ic_discord_monochrome
-                } else {
                     R.drawable.ic_discord_old_monochrome
+                } else {
+                    R.drawable.ic_discord_monochrome
                 }
 
                 container.log("Writing monochrome icon AXML to apk")


### PR DESCRIPTION
This change inverts which monochrome icon is applied based off the user's chosen icon (so that it matches)

Before:

<img width="431" height="276" alt="8ecd25e1-b96f-40c3-b2ac-9c96ba8ea635" src="https://github.com/user-attachments/assets/fc5d210d-69ba-4b2e-9b09-d818119ac0ce" />
<img width="415" height="299" alt="35fdb972-e1ef-4734-8573-b504e5c66eb6" src="https://github.com/user-attachments/assets/4ca6d0a3-985c-40fe-89ff-7dc3a483344b" />

After:

<img width="406" height="272" alt="67013e25-f5fd-477e-90f4-d3495e6a2764" src="https://github.com/user-attachments/assets/b03cf52d-bd8c-4ce1-a750-6dd1c04a924b" />
<img width="436" height="273" alt="add9866b-03f0-41f1-9041-8f4e8b54c052" src="https://github.com/user-attachments/assets/42e59a03-9620-43d6-8de7-b2c9bbab7c46" />

lmk if changes are needed :D