### PR TITLE
fix: migrate from rawgithub to jsdelivr and builds.aliucord.com to solve download failures

### DIFF
--- a/app/src/main/kotlin/com/aliucord/manager/network/services/AliucordGithubService.kt
+++ b/app/src/main/kotlin/com/aliucord/manager/network/services/AliucordGithubService.kt
@@ -37,6 +37,6 @@ class AliucordGithubService(
         const val MAIN_REPO = "Aliucord"
         const val MANAGER_REPO = "Manager"
 
-        const val DATA_JSON_URL = "https://raw.githubusercontent.com/$ORG/$MAIN_REPO/builds/data.json"
+        const val DATA_JSON_URL = "https://builds.aliucord.com/data.json"
     }
 }

--- a/app/src/main/kotlin/com/aliucord/manager/patcher/steps/download/DownloadInjectorStep.kt
+++ b/app/src/main/kotlin/com/aliucord/manager/patcher/steps/download/DownloadInjectorStep.kt
@@ -87,7 +87,7 @@ class DownloadInjectorStep : DownloadStep(), IDexProvider, KoinComponent {
         const val ORG = "Aliucord"
         const val MAIN_REPO = "Aliucord"
 
-        const val URL = "https://raw.githubusercontent.com/$ORG/$MAIN_REPO/builds/Injector.dex"
+        const val URL = "https://builds.aliucord.com/Injector.dex"
     }
 
     override val dexCount = 1

--- a/app/src/main/kotlin/com/aliucord/manager/patcher/steps/download/DownloadKotlinStep.kt
+++ b/app/src/main/kotlin/com/aliucord/manager/patcher/steps/download/DownloadKotlinStep.kt
@@ -25,7 +25,7 @@ class DownloadKotlinStep : DownloadStep(), IDexProvider, KoinComponent {
         const val ORG = "Aliucord"
         const val MAIN_REPO = "Aliucord"
 
-        const val URL = "https://raw.githubusercontent.com/$ORG/$MAIN_REPO/main/installer/android/app/src/main/assets/kotlin/classes.dex"
+        const val URL = "https://cdn.jsdelivr.net/gh/$ORG/$MAIN_REPO@main/installer/android/app/src/main/assets/kotlin/classes.dex"
     }
 
     override val dexCount = 1

--- a/app/src/main/kotlin/com/aliucord/manager/patcher/steps/download/DownloadPatchesStep.kt
+++ b/app/src/main/kotlin/com/aliucord/manager/patcher/steps/download/DownloadPatchesStep.kt
@@ -85,6 +85,6 @@ class DownloadPatchesStep : DownloadStep(), KoinComponent {
         const val ORG = "Aliucord"
         const val MAIN_REPO = "Aliucord"
 
-        const val URL = "https://raw.githubusercontent.com/$ORG/$MAIN_REPO/builds/patches.zip"
+        const val URL = "https://builds.aliucord.com/patches.zip"
     }
 }

--- a/app/src/main/kotlin/com/aliucord/manager/ui/screens/plugins/model/PluginManifest.kt
+++ b/app/src/main/kotlin/com/aliucord/manager/ui/screens/plugins/model/PluginManifest.kt
@@ -18,9 +18,10 @@ data class PluginManifest(
     val changelogMedia: String?,
 ) {
     val repositoryUrl: String
-        get() = updateUrl
-            .replace("raw.githubusercontent.com", "github.com")
-            .replaceFirst("/builds.*".toRegex(), "")
+        get() = updateUrl.replaceFirst(
+            "https://(raw\\.githubusercontent\\.com|cdn\\.jsdelivr\\.net/gh)/([^/]+)/([^/@]+).*".toRegex(),
+            "https://github.com/$2/$3"
+        )
 
     @Immutable
     @Serializable


### PR DESCRIPTION
Migrates all raw.githubusercontent.com urls to cdn.jsdelivr.net and builds.aliucord.com, to solve all `429: Too Many Requests` errors and download failures on CGNAT networks after recent GitHub rate limit enforcements.